### PR TITLE
Modified the code to compile under CUDA 7.0, VS 2013, vtk 6.2.0.

### DIFF
--- a/src/host_side.cpp
+++ b/src/host_side.cpp
@@ -471,9 +471,9 @@ void Voxelizer<Node>::allocStaticMem( DevContext<Node> & device )
 
     device.indices_gpu.copyFrom( &this->indices[0] );
 
-    device.tileOverlaps.reserve( this->hostVars.nrOfTriangles );
+    device.tileOverlaps.resize( this->hostVars.nrOfTriangles );
     
-    device.offsetBuffer.reserve( this->hostVars.nrOfTriangles );
+    device.offsetBuffer.resize( this->hostVars.nrOfTriangles );
 }
 ///////////////////////////////////////////////////////////////////////////////
 /// When repeatedly calling \p performVoxelization() in order to consecutively 

--- a/src/voxelizer.cu
+++ b/src/voxelizer.cu
@@ -6,8 +6,8 @@
 #include <cuda_runtime_api.h>
 #include <device_functions.h>
 #include <device_launch_parameters.h>
-#include <sm_11_atomic_functions.h>
-#include <sm_12_atomic_functions.h>
+//#include <sm_11_atomic_functions.h>
+//#include <sm_12_atomic_functions.h>
 #include <sm_20_atomic_functions.h>
 #include <sm_35_atomic_functions.h>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ file( GLOB TEST_HEADERS . include/*.h )
 
 link_directories( ${CMAKE_CURRENT_BINARY_DIR}/../lib ) 
 find_package( VTK REQUIRED )
+include(${VTK_USE_FILE})
 
 # Require Boost >= 1.53 with system and thread components.
 find_package( Boost 1.53 REQUIRED COMPONENTS system program_options thread date_time chrono )

--- a/tests/src/main.cpp
+++ b/tests/src/main.cpp
@@ -6,7 +6,9 @@
 #include <vtkSmartPointer.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkPolyDataReader.h>
+#include <vtkSTLReader.h>
 #include <vtkPLYReader.h>
+#include <vtkOBJReader.h>
 #include <vtkProperty.h>
 
 #include <vtkQuad.h>
@@ -383,11 +385,28 @@ int main(int argc, char** argv)
             reader->Update();
             polys = reader->GetOutput();
         }
+		if (file.rfind( ".stl") != std::string::npos)
+		{
+			vtkSmartPointer<vtkSTLReader> reader =
+				vtkSmartPointer<vtkSTLReader>::New();
+			reader->SetFileName(file.c_str());
+			reader->Update();
+			polys = reader->GetOutput();
+		}
+		if (file.rfind(".obj") != std::string::npos)
+		{
+			vtkSmartPointer<vtkOBJReader> reader =
+				vtkSmartPointer<vtkOBJReader>::New();
+			reader->SetFileName(file.c_str());
+			reader->Update();
+			polys = reader->GetOutput();
+		}
     }
 
     if ( polys.GetPointer() == NULL )
     {
         std::cout << "Invalid filename given" << std::endl;
+		return -1;
     }
 
     // Fail if bad model data was received.
@@ -491,7 +510,7 @@ void visualize(vtkPolyData* data, double3 minVertex, double3 maxVertex, double d
     data->SetLines(lines);
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-    mapper->SetInput(data);
+    mapper->SetInputData(data);
  
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();
     actor->SetMapper(mapper);
@@ -555,7 +574,7 @@ void renderVoxelization(unsigned int* voxels, bool onlySurface, uint3 res)
     data->SetVerts(cells);
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-    mapper->SetInput(data);
+    mapper->SetInputData(data);
 
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();
     actor->SetMapper(mapper);
@@ -635,7 +654,7 @@ void renderNodeOutput(NT* nodes, bool onlySurface, bool materials, uint3 res)
     data->SetPoints(points);
 
     vtkSmartPointer<vtkVertexGlyphFilter> vertexFilter = vtkSmartPointer<vtkVertexGlyphFilter>::New();
-    vertexFilter->SetInputConnection(data->GetProducerPort());
+    vertexFilter->SetInputData(data);
     vertexFilter->Update();
 
     vtkSmartPointer<vtkPolyData> polydata = vtkSmartPointer<vtkPolyData>::New();
@@ -644,7 +663,7 @@ void renderNodeOutput(NT* nodes, bool onlySurface, bool materials, uint3 res)
     polydata->GetPointData()->SetScalars(colors);
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-    mapper->SetInput(polydata);
+    mapper->SetInputData(polydata);
 
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();
     actor->SetMapper(mapper);
@@ -1476,7 +1495,7 @@ void renderFCCNodeOutput(NT* nodes, bool onlySurface, bool materials, uint3 res)
     data->SetPoints(points);
 
     vtkSmartPointer<vtkVertexGlyphFilter> vertexFilter = vtkSmartPointer<vtkVertexGlyphFilter>::New();
-    vertexFilter->SetInputConnection(data->GetProducerPort());
+    vertexFilter->SetInputData(data);
     vertexFilter->Update();
 
     vtkSmartPointer<vtkPolyData> polydata = vtkSmartPointer<vtkPolyData>::New();
@@ -1485,7 +1504,7 @@ void renderFCCNodeOutput(NT* nodes, bool onlySurface, bool materials, uint3 res)
     polydata->GetPointData()->SetScalars(colors);
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-    mapper->SetInput(polydata);
+    mapper->SetInputData(polydata);
 
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();
     actor->SetMapper(mapper);


### PR DESCRIPTION
Modified the code to compile under CUDA 7.0, VS 2013, vtk 6.2.0.
Bug fix for host_side.cpp to avoid array exceed bounds exception.
Added 3D file format support for STL and OBJ.

modified:   src/host_side.cpp
    Using std::vector.reserve() only modifies the capability but not size of an vector,
    causing the code throws an array exceed bounds exception when accessing data
    using [] operator. Using resize() function would be safer.

modified:   src/voxelizer.cu
    sm_11_atomic_functions.h And sm_12_atomic_functions.h exists no more in cuda 7.0.

modified:   tests/CMakeLists.txt
modified:   tests/src/main.cpp
    Modified to compile with vtk 6.2.0. Add support for STL and OBJ.
