### PR TITLE
A bug fix for release version of the program.

### DIFF
--- a/include/voxelizer.h
+++ b/include/voxelizer.h
@@ -23,7 +23,7 @@
 ///
 /// The voxelization produced by the various modes of the program revolves 
 /// around the concept of a voxel center. As long as the center of the voxel 
-/// is inside of the volume defined by a thre dimensional mesh, the voxel is 
+/// is inside of the volume defined by a three dimensional mesh, the voxel is 
 /// considered to be \a solid. This is the case for all voxelizations without 
 /// material data attached to them. If material data is enabled, then the 
 /// surface voxelizer will generate a shell of voxels that abide by a different 

--- a/src/host_side.cpp
+++ b/src/host_side.cpp
@@ -47,6 +47,8 @@ template <class Node> Voxelizer<Node>::Voxelizer(
         std::vector<uint>( _indices, _indices + 3*_nrOfTriangles );
 
     this->calculateBoundingBox();
+
+	nrOfDevicesInUse = 0;
 }
 ///////////////////////////////////////////////////////////////////////////////
 /// Constructs the voxelizer as well as supplies material information.
@@ -90,6 +92,8 @@ template <class Node> Voxelizer<Node>::Voxelizer(
         std::vector<uint>( _indices, _indices + 3*_nrOfTriangles );
 
     this->calculateBoundingBox();
+
+	nrOfDevicesInUse = 0;
 
     this->setMaterials( _materials, _nrOfUniqueMaterials );
 }


### PR DESCRIPTION
modified:   src/host_side.cpp
int nrOfDevicesInUse is not explicitly initialize in the constructor causing an
access violent in setMaterial function when performing the following line:

```
    for ( int d = 0; d < this->nrOfDevicesInUse; ++d ) this->devices[d].materials_gpu.reset();
```

This only happens in a release version of the program.

modified:   src/host_side.cpp
    A typo in comment.
