### PR TITLE
Next 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ option( GENERATE_TESTS "Adds the compilation of a test program as a target." OFF
 
 # Configuration-dependent settings.
 set( CMAKE_DEBUG_POSTFIX "_d" )
-set( CUDA_NVCC_FLAGS_RELEASE ${CUDA_NVCC_FLAGS_RELEASE};-gencode arch=compute_30,code=sm_30 )
-set( CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG};-gencode arch=compute_30,code=sm_30 )
+set( CUDA_NVCC_FLAGS_RELEASE ${CUDA_NVCC_FLAGS_RELEASE};-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 )
+set( CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG};-gencode arch=compute_60,code=sm_60 -gencode arch=compute_61,code=sm_61 )
 
 # Unix-specific compiler flags. 
 if ( UNIX )

--- a/include/common.h
+++ b/include/common.h
@@ -5,11 +5,7 @@
 #ifndef VOX_COMMON_H
 #define VOX_COMMON_H
 
-#if defined(unix) || defined(__unix__) || defined(__unix)
 #include <stdint.h>
-#else
-#include <stdint.h>
-#endif
 
 #include <limits>
 #include <cuda.h>

--- a/src/voxelizer.cu
+++ b/src/voxelizer.cu
@@ -19,8 +19,10 @@
 #include <thrust/copy.h>
 #include <thrust/unique.h>
 #include <thrust/count.h>
+#if defined(unix) || defined(__unix__) || defined(__unix)
 #include <thrust/device_malloc.h>
 #include <thrust/device_free.h>
+#endif 
 
 #include <iostream>
 #include <ctime>

--- a/src/voxelizer.cu
+++ b/src/voxelizer.cu
@@ -19,6 +19,8 @@
 #include <thrust/copy.h>
 #include <thrust/unique.h>
 #include <thrust/count.h>
+#include <thrust/device_malloc.h>
+#include <thrust/device_free.h>
 
 #include <iostream>
 #include <ctime>


### PR DESCRIPTION
Updates from Aalto RSEs to help compile on Triton.

Including the two headers in voxelizer.cu could impact compilation on Windows, so but I don't have the equipment to check. If they don't, the guards around them can be removed.